### PR TITLE
Specify ghc version in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+with-compiler: ghc-9.2.5
 packages:
     ./
     ./cpphs-1.20.9.1


### PR DESCRIPTION
The ghc version is fixed to ghc-9.2.5 by the bounds on base in haskell-gtd.cabal, but cabal doesn't automatically choose a ghc version from just those bounds.